### PR TITLE
Use nodeselector/tolerations instead of pod label for arch

### DIFF
--- a/engine/compiler/compiler.go
+++ b/engine/compiler/compiler.go
@@ -330,7 +330,20 @@ func (c *Compiler) Compile(ctx context.Context, args runtime.CompilerArgs) runti
 
 	// set platform if needed
 	if arch == "arm" || arch == "arm64" {
-		spec.PodSpec.Labels["kubernetes.io/arch"] = arch
+		if spec.PodSpec.NodeSelector == nil {
+			spec.PodSpec.NodeSelector = map[string]string{}
+		}
+
+		spec.PodSpec.NodeSelector["kubernetes.io/arch"] = arch
+
+		armToleration := engine.Toleration{
+			Key:      "kubernetes.io/arch",
+			Operator: "Equal",
+			Value:    arch,
+			Effect:   "NoSchedule",
+		}
+
+		spec.PodSpec.Tolerations = append(spec.PodSpec.Tolerations, armToleration)
 	}
 
 	// set drone labels

--- a/engine/compiler/compiler_test.go
+++ b/engine/compiler/compiler_test.go
@@ -104,6 +104,10 @@ func TestCompile_RunFailure(t *testing.T) {
 	}
 }
 
+func TestPlatformNodeSelector(t *testing.T) {
+	testCompile(t, "testdata/arm.yml", "testdata/arm.json")
+}
+
 // This test verifies that secrets defined in the yaml are
 // requested and stored in the intermediate representation
 // at compile time.

--- a/engine/compiler/testdata/arm.json
+++ b/engine/compiler/testdata/arm.json
@@ -1,0 +1,123 @@
+{
+  "platform": {
+    "arch": "arm"
+  },
+  "pod_spec": {
+    "name": "random",
+    "labels": {},
+    "annotations": {},
+    "node_selector": {
+      "kubernetes.io/arch": "arm"
+    },
+    "tolerations": [
+      {
+        "key": "kubernetes.io/arch",
+        "operator": "Equal",
+        "value": "arm",
+        "effect": "NoSchedule"
+      }
+    ]
+  },
+  "steps": [
+    {
+      "id": "random",
+      "environment": {},
+      "image": "drone/git:latest",
+      "placeholder": "drone/placeholder:1",
+      "labels": {},
+      "name": "clone",
+      "run_policy": "always",
+      "volumes": [
+        {
+          "name": "_workspace",
+          "path": "/drone/src"
+        },
+        {
+          "name": "_status",
+          "path": "/run/drone"
+        }
+      ],
+      "working_dir": "/drone/src"
+    },
+    {
+      "id": "random",
+      "args": [
+        "echo \"$DRONE_SCRIPT\" | /bin/sh"
+      ],
+      "depends_on": [
+        "clone"
+      ],
+      "entrypoint": [
+        "/bin/sh",
+        "-c"
+      ],
+      "environment": {},
+      "labels": {},
+      "name": "build",
+      "image": "docker.io/library/golang:latest",
+      "placeholder": "drone/placeholder:1",
+      "volumes": [
+        {
+          "name": "_workspace",
+          "path": "/drone/src"
+        },
+        {
+          "name": "_status",
+          "path": "/run/drone"
+        }
+      ],
+      "working_dir": "/drone/src"
+    },
+    {
+      "id": "random",
+      "args": [
+        "echo \"$DRONE_SCRIPT\" | /bin/sh"
+      ],
+      "depends_on": [
+        "build"
+      ],
+      "entrypoint": [
+        "/bin/sh",
+        "-c"
+      ],
+      "environment": {},
+      "labels": {},
+      "name": "test",
+      "image": "docker.io/library/golang:latest",
+      "placeholder": "drone/placeholder:1",
+      "volumes": [
+        {
+          "name": "_workspace",
+          "path": "/drone/src"
+        },
+        {
+          "name": "_status",
+          "path": "/run/drone"
+        }
+      ],
+      "working_dir": "/drone/src"
+    }
+  ],
+  "volumes": [
+    {
+      "temp": {
+        "id": "random",
+        "name": "_workspace",
+        "labels": {}
+      }
+    },
+    {
+      "downward_api": {
+        "id": "random",
+        "name": "_status",
+        "items": [
+          {
+            "path": "env",
+            "field_path": "metadata.annotations"
+          }
+        ]
+      }
+    }
+  ],
+  "secrets": {}
+}

--- a/engine/compiler/testdata/arm.yml
+++ b/engine/compiler/testdata/arm.yml
@@ -1,0 +1,17 @@
+kind: pipeline
+type: kubernetes
+name: default
+
+platform:
+  arch: arm
+
+steps:
+- name: build
+  image: golang
+  commands:
+  - go build
+
+- name: test
+  image: golang
+  commands:
+  - go test


### PR DESCRIPTION
Hopefully this will get [merged upstream](https://github.com/drone-runners/drone-runner-kube/pull/94), but creating a PR against the `release` branch for now in order to build a custom image.

 ---

As outlined in https://kubernetes.io/docs/reference/labels-annotations-taints/#kubernetes-io-arch, the `kubernetes.io/arch` label is `Used on: Node` and is populated by the kubelet using with the value of `runtime.GOARCH`.

This means that runner pods should populate a NodeSelector in order to select nodes that k8s has labeled with `kubernetes.io/arch=arm64`.

This also adds a commonly used `toleration` for `arm64` nodes. For example, this is [how GKE handles scheduling arm64 workloads](https://cloud.google.com/kubernetes-engine/docs/how-to/prepare-arm-workloads-for-deployment#overview).

Fixes https://community.harness.io/t/kubernetes-runner-kubernetes-pipelines-being-assigned-to-runners-of-the-wrong-architecture/11564