### PR TITLE
command/exec: ensure DRONE_STEP_NUMBER is populated

### DIFF
--- a/command/exec.go
+++ b/command/exec.go
@@ -222,13 +222,18 @@ func (c *execCommand) run(*kingpin.ParseContext) error {
 		if step.RunPolicy == runtime.RunNever {
 			continue
 		}
-		c.Stage.Steps = append(c.Stage.Steps, &drone.Step{
+
+		droneStep := &drone.Step{
 			StageID:   c.Stage.ID,
 			Number:    len(c.Stage.Steps) + 1,
 			Name:      step.Name,
 			Status:    drone.StatusPending,
 			ErrIgnore: step.ErrPolicy == runtime.ErrIgnore,
-		})
+		}
+
+		c.Stage.Steps = append(c.Stage.Steps, droneStep)
+
+		step.Envs = environ.Combine(step.Envs, environ.Step(droneStep))
 	}
 
 	// configures the pipeline timeout.


### PR DESCRIPTION
This code is a huge mess, and I found a whole host of stuff that I believe is unused. This is almost certainly not what a proper fix would look like, but it should work.

In short, Drone's runner-go.Engine interface for running pipelines is awkward when run in Kubernetes. The engine actually does set env vars including DRONE_STEP_NUMBER automatically before calls to Engine.Run(). However, the k8s driver used here sets container env vars itself in its Engine.Setup() implementation. The later env vars that Run() adds are never used. This means that we need to handle the variables ourselves before Setup() is called.

The existing code already looped over steps in a way where the step number was known, so I manually added the step information to our env map.

