### PR TITLE
Bump runner go from arch release adding support for Clone Retries

### DIFF
--- a/engine/compiler/clone.go
+++ b/engine/compiler/clone.go
@@ -38,6 +38,10 @@ func cloneParams(src manifest.Clone) map[string]string {
 		dst["GIT_SSL_NO_VERIFY"] = "true"
 		dst["PLUGIN_SKIP_VERIFY"] = "true"
 	}
+
+	if src.Retries > 0 {
+		dst["PLUGIN_RETRIES"] = strconv.Itoa(src.Retries)
+	}
 	return dst
 }
 

--- a/engine/compiler/clone_test.go
+++ b/engine/compiler/clone_test.go
@@ -51,11 +51,11 @@ func TestClone(t *testing.T) {
 			RunPolicy:   runtime.RunAlways,
 			WorkingDir:  "/drone/src",
 			Volumes: []*engine.VolumeMount{
-				&engine.VolumeMount{
+				{
 					Name: "_workspace",
 					Path: "/drone/src",
 				},
-				&engine.VolumeMount{
+				{
 					Name: "_status",
 					Path: "/run/drone",
 				},
@@ -140,7 +140,7 @@ func TestCloneParams(t *testing.T) {
 	if len(params) != 0 {
 		t.Errorf("Expect zero depth ignored")
 	}
-	params = cloneParams(manifest.Clone{Depth: 50, SkipVerify: true})
+	params = cloneParams(manifest.Clone{Depth: 50, SkipVerify: true, Retries: 1})
 	if params["PLUGIN_DEPTH"] != "50" {
 		t.Errorf("Expect clone depth 50")
 	}
@@ -149,5 +149,8 @@ func TestCloneParams(t *testing.T) {
 	}
 	if params["PLUGIN_SKIP_VERIFY"] != "true" {
 		t.Errorf("Expect PLUGIN_SKIP_VERIFY is true")
+	}
+	if params["PLUGIN_RETRIES"] != "1" {
+		t.Errorf("Expect PLUGIN_RETRIES is 1")
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/docker/go-units v0.4.0
 	github.com/drone/drone-go v1.7.1
 	github.com/drone/envsubst v1.0.3
-	github.com/drone/runner-go v1.11.0
+	github.com/drone/runner-go v1.12.0
 	github.com/drone/signal v1.0.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/golang/mock v1.4.1

--- a/go.sum
+++ b/go.sum
@@ -70,8 +70,8 @@ github.com/drone/drone-go v1.7.1/go.mod h1:fxCf9jAnXDZV1yDr0ckTuWd1intvcQwfJmTRp
 github.com/drone/envsubst v1.0.2/go.mod h1:bkZbnc/2vh1M12Ecn7EYScpI4YGYU0etwLJICOWi8Z0=
 github.com/drone/envsubst v1.0.3 h1:PCIBwNDYjs50AsLZPYdfhSATKaRg/FJmDc2D6+C2x8g=
 github.com/drone/envsubst v1.0.3/go.mod h1:N2jZmlMufstn1KEqvbHjw40h1KyTmnVzHcSc9bFiJ2g=
-github.com/drone/runner-go v1.11.0 h1:zcn8Hmi0H1I4pxdJCauykG5teu3AH84Uw4WM7VrKlIM=
-github.com/drone/runner-go v1.11.0/go.mod h1:vu4pPPYDoeN6vdYQAY01GGGsAIW4aLganJNaa8Fx8zE=
+github.com/drone/runner-go v1.12.0 h1:zUjDj9ylsJ4n4Mvy4znddq/Z4EBzcUXzTltpzokKtgs=
+github.com/drone/runner-go v1.12.0/go.mod h1:vu4pPPYDoeN6vdYQAY01GGGsAIW4aLganJNaa8Fx8zE=
 github.com/drone/signal v1.0.0 h1:NrnM2M/4yAuU/tXs6RP1a1ZfxnaHwYkd0kJurA1p6uI=
 github.com/drone/signal v1.0.0/go.mod h1:S8t92eFT0g4WUgEc/LxG+LCuiskpMNsG0ajAMGnyZpc=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=


### PR DESCRIPTION
This adds support for clone retries within the drone kube-runner.